### PR TITLE
fix some clippy warnings

### DIFF
--- a/lib.rs
+++ b/lib.rs
@@ -345,7 +345,7 @@ impl<T: Write> ConsoleTestState<T> {
     }
 
     pub fn write_run_finish(&mut self) -> io::Result<bool> {
-        assert!(self.passed + self.failed + self.ignored + self.measured == self.total);
+        assert_eq!(self.passed + self.failed + self.ignored + self.measured, self.total);
 
         let success = self.failed == 0;
         if !success {
@@ -565,11 +565,11 @@ fn run_test(_opts: &TestOpts,
     match testfn {
         DynBenchFn(bencher) => {
             let bs = ::bench::benchmark(|harness| bencher.run(harness));
-            return (desc, TrBench(bs), Vec::new());
+            (desc, TrBench(bs), Vec::new())
         }
         StaticBenchFn(benchfn) => {
             let bs = ::bench::benchmark(|harness| benchfn(harness));
-            return (desc, TrBench(bs), Vec::new());
+            (desc, TrBench(bs), Vec::new())
         }
     }
 }

--- a/macros.rs
+++ b/macros.rs
@@ -36,9 +36,8 @@ macro_rules! benchmark_main {
             use $crate::run_tests_console;
             let mut test_opts = TestOpts::default();
             // check to see if we should filter:
-            for arg in ::std::env::args().skip(1).filter(|arg| *arg != "--bench") {
+            if let Some(arg) = ::std::env::args().skip(1).find(|arg| *arg != "--bench") {
                 test_opts.filter = Some(arg);
-                break;
             }
             let mut benches = Vec::new();
             $(


### PR DESCRIPTION
Just an ` assert!` → `assert_eq!`, two needless `return`s and a loop where we have perfectly fine iterator functions. The code is already pretty readable. :+1: