### PR TITLE
Add a .gitignore file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+/Cargo.lock
+/target/


### PR DESCRIPTION
This ignores the compiler output (`target/` directory) and the
`Cargo.lock` file produced by Cargo.