### PR TITLE
The scope of the unsafe block can be appropriately reduced

### DIFF
--- a/lib.rs
+++ b/lib.rs
@@ -588,11 +588,11 @@ fn run_test(_opts: &TestOpts,
 /// pretend to use outputs to assist in avoiding dead-code
 /// elimination.
 pub fn black_box<T>(dummy: T) -> T {
-    unsafe {
-        let ret = ptr::read_volatile(&dummy);
+    
+        let ret = unsafe { ptr::read_volatile(&dummy) };
         forget(dummy);
         ret
-    }
+    
 }
 
 


### PR DESCRIPTION
In this function you use the unsafe keyword for almost the entrie function body. However, I found that only 1 function is real unsafe operation (see the list below). 

We need to mark unsafe operations more precisely using unsafe keyword. Keeping unsafe blocks small can bring many benefits. For example, when mistakes happen, we can locate any errors related to memory safety  within an unsafe block. This is the balance between Safe and Unsafe Rust. The separation is designed to make using Safe Rust as ergonomic as possible, but requires extra effort and care when writing Unsafe Rust. 
**Real unsafe operation list:**
1. the read_volatile() function(unsafe function)

@bluss
Hope this PR can help you.
Best regards.
**References**
https://doc.rust-lang.org/nomicon/safe-unsafe-meaning.html 
https://doc.rust-lang.org/book/ch19-01-unsafe-rust.html 